### PR TITLE
Housekeeping: .gitignore, README, repo description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# OpenTofu / Terraform
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars
+*.tfvars.json
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+crash.log
+crash.*.log
+
+# OS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# aws-formae
-Using formae to manage some AWS resources
+# aws-infra
+
+Managing Otto's AWS infrastructure using [OpenTofu](https://opentofu.org), following [AWS Organizations best practices](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_best-practices.html).
+
+See [CLAUDE.md](CLAUDE.md) for conventions, account structure, and bootstrap status.


### PR DESCRIPTION
## Summary

- Adds `.gitignore` covering OpenTofu state files, `.terraform/` dirs, tfvars files, and crash logs
- Updates `README.md` to reflect OpenTofu (was still referencing formae)
- Updates GitHub repo description to match

## Test plan

- [x] All prek hooks pass
- [x] `.terraform/` and `*.tfstate` patterns confirmed in .gitignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)