### PR TITLE
Add bootstrap: S3 state bucket and DynamoDB lock table

### DIFF
--- a/bootstrap/main.tf
+++ b/bootstrap/main.tf
@@ -1,0 +1,55 @@
+resource "aws_s3_bucket" "state" {
+  bucket = "ojhermann-tofu-state"
+
+  tags = {
+    Name       = "ojhermann-tofu-state"
+    env        = "management"
+    service    = "shared"
+    managed-by = "opentofu"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "state" {
+  bucket = aws_s3_bucket.state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "state" {
+  bucket = aws_s3_bucket.state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "state" {
+  bucket = aws_s3_bucket.state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_dynamodb_table" "locks" {
+  name         = "ojhermann-tofu-locks"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = {
+    Name       = "ojhermann-tofu-locks"
+    env        = "management"
+    service    = "shared"
+    managed-by = "opentofu"
+  }
+}

--- a/bootstrap/providers.tf
+++ b/bootstrap/providers.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region  = "us-east-1"
+  profile = "otto-management"
+}

--- a/bootstrap/versions.tf
+++ b/bootstrap/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.8"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Creates `bootstrap/` OpenTofu configuration (local state — this is the bootstrapper)
- S3 bucket `ojhermann-tofu-state` with versioning, AES256 encryption, and public access block
- DynamoDB table `ojhermann-tofu-locks` (PAY_PER_REQUEST) for state locking
- All resources tagged per convention (`env=management`, `service=shared`, `managed-by=opentofu`)

## Test plan

- [ ] `tofu init` in `bootstrap/` with `otto-management` profile active
- [ ] `tofu plan` — confirm two resources (S3 bucket + DynamoDB table) planned
- [ ] `tofu apply` — confirm both resources created in AWS console
- [ ] Verify bucket versioning and encryption are enabled
- [ ] Verify DynamoDB table has `LockID` hash key

🤖 Generated with [Claude Code](https://claude.com/claude-code)