### PR TITLE
Add direnv config for automatic AWS profile switching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,8 @@ override.tf.json
 crash.log
 crash.*.log
 
+# direnv
+.direnv/
+
 # OS
 .DS_Store

--- a/management/.envrc
+++ b/management/.envrc
@@ -1,0 +1,1 @@
+export AWS_PROFILE=otto-management


### PR DESCRIPTION
## Summary

- `management/.envrc`: sets `AWS_PROFILE=otto-management` automatically on `cd`
- `.gitignore`: adds `.direnv/` (direnv's local cache directory)

As new account directories (`dev/`, `stage/`, `prod/`) are added, each gets its own `.envrc` with the appropriate profile.

## After merging / cloning

Run `direnv allow` once in each directory that has an `.envrc`:

```
cd management && direnv allow
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)