### PR TITLE
Assign admins/AdministratorAccess to member accounts; update CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,10 +23,10 @@ Root (ojhermann-org)
 ├── Management account (324621155013)  — governance only, no workloads
 └── Workloads OU
     ├── SDLC OU
-    │   ├── Dev account
-    │   └── Stage account
+    │   ├── Dev account (916868258956)
+    │   └── Stage account (039914330850)
     └── Prod OU
-        └── Prod account
+        └── Prod account (425924866611)
 ```
 
 Within each workload account: one VPC per service.
@@ -36,9 +36,9 @@ Within each workload account: one VPC per service.
 | Profile | Account | Purpose |
 |---------|---------|---------|
 | `otto-management` | 324621155013 | Org governance, account creation |
-| `otto-dev` | TBD | Dev workloads |
-| `otto-stage` | TBD | Stage workloads |
-| `otto-prod` | TBD | Prod workloads |
+| `otto-dev` | 916868258956 | Dev workloads |
+| `otto-stage` | 039914330850 | Stage workloads |
+| `otto-prod` | 425924866611 | Prod workloads |
 
 ## Identity and access
 
@@ -119,9 +119,9 @@ Guidelines:
 - [x] Confirm AWS Organization exists (`o-3b7bm2b2yf`), feature set ALL
 - [x] Tag org root with `Name=ojhermann-org`
 - [x] Set up AWS Budget alert on management account (created manually as `ojhermann-monthly-budget`; import into `management/` via `tofu import` once that directory is set up)
-- [ ] Create S3 state bucket and DynamoDB lock table (`bootstrap/`)
-- [ ] Create OU structure (Workloads → SDLC, Prod) (`management/`)
-- [ ] Create member accounts (dev, stage, prod) (`management/`)
+- [x] Create S3 state bucket and DynamoDB lock table (`bootstrap/`)
+- [x] Create OU structure (Workloads → SDLC, Prod) (`management/`)
+- [x] Create member accounts (dev, stage, prod) (`management/`)
 - [ ] Assign `admins` group + `AdministratorAccess` to each member account
 - [ ] Configure CLI profiles for each member account
 - [ ] Begin managing workload resources per account

--- a/management/sso.tf
+++ b/management/sso.tf
@@ -1,0 +1,44 @@
+data "aws_ssoadmin_instances" "main" {}
+
+data "aws_ssoadmin_permission_set" "administrator" {
+  instance_arn = tolist(data.aws_ssoadmin_instances.main.arns)[0]
+  name         = "AdministratorAccess"
+}
+
+data "aws_identitystore_group" "admins" {
+  identity_store_id = tolist(data.aws_ssoadmin_instances.main.identity_store_ids)[0]
+
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "DisplayName"
+      attribute_value = "admins"
+    }
+  }
+}
+
+resource "aws_ssoadmin_account_assignment" "dev_admins" {
+  instance_arn       = tolist(data.aws_ssoadmin_instances.main.arns)[0]
+  permission_set_arn = data.aws_ssoadmin_permission_set.administrator.arn
+  principal_id       = data.aws_identitystore_group.admins.group_id
+  principal_type     = "GROUP"
+  target_id          = aws_organizations_account.dev.id
+  target_type        = "AWS_ACCOUNT"
+}
+
+resource "aws_ssoadmin_account_assignment" "stage_admins" {
+  instance_arn       = tolist(data.aws_ssoadmin_instances.main.arns)[0]
+  permission_set_arn = data.aws_ssoadmin_permission_set.administrator.arn
+  principal_id       = data.aws_identitystore_group.admins.group_id
+  principal_type     = "GROUP"
+  target_id          = aws_organizations_account.stage.id
+  target_type        = "AWS_ACCOUNT"
+}
+
+resource "aws_ssoadmin_account_assignment" "prod_admins" {
+  instance_arn       = tolist(data.aws_ssoadmin_instances.main.arns)[0]
+  permission_set_arn = data.aws_ssoadmin_permission_set.administrator.arn
+  principal_id       = data.aws_identitystore_group.admins.group_id
+  principal_type     = "GROUP"
+  target_id          = aws_organizations_account.prod.id
+  target_type        = "AWS_ACCOUNT"
+}


### PR DESCRIPTION
## Summary

- `management/sso.tf`: assigns `admins` group + `AdministratorAccess` permission set to dev, stage, and prod accounts via IAM Identity Center; applied locally before opening PR
- `CLAUDE.md`: fills in account IDs, marks bootstrap steps as complete

## Test plan

- [x] CI passes (plan shows no changes)
- [ ] Verify `aws sso login --profile otto-dev` works after merging and running `aws configure sso`

🤖 Generated with [Claude Code](https://claude.com/claude-code)