### PR TITLE
Import monthly-budget into management/ state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,10 +118,11 @@ Guidelines:
 - [x] Verify CLI access (`aws sts get-caller-identity --profile otto-management`)
 - [x] Confirm AWS Organization exists (`o-3b7bm2b2yf`), feature set ALL
 - [x] Tag org root with `Name=ojhermann-org`
-- [x] Set up AWS Budget alert on management account (created manually as `ojhermann-monthly-budget`; import into `management/` via `tofu import` once that directory is set up)
+- [x] Set up AWS Budget alert on management account (created manually as `monthly-budget`; imported into `management/`)
 - [x] Create S3 state bucket and DynamoDB lock table (`bootstrap/`)
 - [x] Create OU structure (Workloads → SDLC, Prod) (`management/`)
 - [x] Create member accounts (dev, stage, prod) (`management/`)
-- [ ] Assign `admins` group + `AdministratorAccess` to each member account
-- [ ] Configure CLI profiles for each member account
+- [x] Assign `admins` group + `AdministratorAccess` to each member account
+- [x] Configure CLI profiles for each member account
+- [x] Import budget into `management/`
 - [ ] Begin managing workload resources per account

--- a/management/budget.tf
+++ b/management/budget.tf
@@ -1,0 +1,31 @@
+resource "aws_budgets_budget" "monthly" {
+  name         = "monthly-budget"
+  budget_type  = "COST"
+  limit_amount = "20.0"
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 85
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = ["amazon.finally422@passmail.net"]
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = ["amazon.finally422@passmail.net"]
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "FORECASTED"
+    subscriber_email_addresses = ["amazon.finally422@passmail.net"]
+  }
+}


### PR DESCRIPTION
## Summary

- `management/budget.tf`: defines the existing `monthly-budget` resource ($20/month, COST, three notifications at 85%/100% actual and 100% forecasted)
- Budget imported into state with `tofu import` — plan shows no changes
- `CLAUDE.md`: corrects budget name, marks all remaining bootstrap steps as complete except workload resources

## Notes

The budget has a `NOT RecordType [Credit, Refund]` filter expression set in AWS. The current AWS provider version (~5.0) does not support the `filter_expression` block, so this attribute is unmanaged for now. OpenTofu reports no drift, meaning it does not attempt to remove the filter. This can be revisited if the provider adds support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)