### PR TITLE
Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ojhermann-org


### PR DESCRIPTION
Adds `CODEOWNERS` so all files are owned by `@ojhermann-org`. Required by the org-level ruleset for code owner review on PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)