### PR TITLE
fix: set AWS_PROFILE for terraform_validate pre-commit hook

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -27,6 +27,7 @@ args = ["--args=-recursive"]
 
 [[repos.hooks]]
 id = "terraform_validate"
+env = {AWS_PROFILE = "otto-management"}
 
 [[repos]]
 repo = "https://github.com/gitleaks/gitleaks"


### PR DESCRIPTION
## Summary

- Adds `env = {AWS_PROFILE = "otto-management"}` to the `terraform_validate` prek hook
- The management account has access to the shared S3 state bucket, so `tofu init` can authenticate without the user manually exporting `AWS_PROFILE` before committing

## Test plan

- [ ] Make a terraform change and commit — `terraform_validate` should run without the `'terraform init' failed` error

Closes ojhermann/home-manager#37

🤖 Generated with [Claude Code](https://claude.com/claude-code)