### PR TITLE
fix: upgrade GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -16,12 +16,12 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: actions/checkout@v6
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::324621155013:role/github-actions-apply
           aws-region: us-east-1
-      - uses: opentofu/setup-opentofu@v1
+      - uses: opentofu/setup-opentofu@v2
         with:
           tofu_version: latest
       - name: init

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: opentofu/setup-opentofu@v1
+      - uses: actions/checkout@v6
+      - uses: opentofu/setup-opentofu@v2
         with:
           tofu_version: latest
       - name: Check formatting
@@ -18,7 +18,7 @@ jobs:
   trivy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Scan for misconfigurations
         uses: aquasecurity/trivy-action@v0.35.0
         with:
@@ -41,12 +41,12 @@ jobs:
       matrix:
         directory: [management, dev, stage, prod]
     steps:
-      - uses: actions/checkout@v4
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: actions/checkout@v6
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::324621155013:role/github-actions-plan
           aws-region: us-east-1
-      - uses: opentofu/setup-opentofu@v1
+      - uses: opentofu/setup-opentofu@v2
         with:
           tofu_version: latest
       - name: init


### PR DESCRIPTION
Closes #14

## Summary

- `actions/checkout` v4 → v6
- `aws-actions/configure-aws-credentials` v4 → v6
- `opentofu/setup-opentofu` v1 → v2

All three new major versions target Node.js 24, resolving the deprecation warnings before the June 2, 2026 deadline.

## Test plan

- [ ] CI passes (fmt, trivy, plan jobs all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)