### PR TITLE
fix: upsize jump box to t3.medium with 30 GiB root volume

### DIFF
--- a/management/jump_box_ec2.tf
+++ b/management/jump_box_ec2.tf
@@ -15,7 +15,7 @@ data "aws_ami" "al2023" {
 
 resource "aws_instance" "jump_box" {
   ami                    = data.aws_ami.al2023.id
-  instance_type          = "t3.micro"
+  instance_type          = "t3.medium"
   subnet_id              = aws_subnet.management_public.id
   vpc_security_group_ids = [aws_security_group.jump_box.id]
   iam_instance_profile   = aws_iam_instance_profile.jump_box.name
@@ -47,7 +47,7 @@ resource "aws_instance" "jump_box" {
 
   root_block_device {
     volume_type           = "gp3"
-    volume_size           = 20
+    volume_size           = 30
     encrypted             = true
     delete_on_termination = true
   }


### PR DESCRIPTION
## Summary

- Upsize instance from \`t3.micro\` → \`t3.medium\` (2 vCPU, 4 GiB RAM) to prevent OOM during development
- Expand root EBS volume from 20 GiB → 30 GiB to accommodate the Nix store and Home Manager packages
- \`user_data_replace_on_change = true\` means instance replacement will automatically run the existing Nix bootstrap — no manual steps needed
- Branch protection on \`main\` enabled (all CI checks required to pass before merge) — closes #19

Closes #20

## Test plan

- [x] CI passes (fmt, trivy, plan×4)
- [ ] After merge and \`tofu apply\`: SSM into new instance, confirm \`nix --version\` works
- [ ] Confirm \`df -h\` shows ~30 GiB root volume
- [ ] Confirm memory via \`free -h\` shows ~4 GiB

🤖 Generated with [Claude Code](https://claude.com/claude-code)