### PR TITLE
fix: start bash login shell for SSM sessions and add swapfile

### DIFF
--- a/management/jump_box_ec2.tf
+++ b/management/jump_box_ec2.tf
@@ -26,6 +26,7 @@ resource "aws_instance" "jump_box" {
 
   # Install Nix via Determinate Systems installer (daemon mode, flakes enabled by default).
   # Home Manager is applied separately by the user via ojhermann-org/home-manager.
+  # A 2 GiB swapfile is created to guard against OOM during Nix builds.
   user_data = base64encode(<<-EOT
     #!/bin/bash
     set -euo pipefail
@@ -35,6 +36,12 @@ resource "aws_instance" "jump_box" {
     # would not be on PATH without this. Sourcing nix-daemon.sh in .bashrc fixes it.
     echo 'source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' \
       >> /home/ec2-user/.bashrc
+    # Create a 2 GiB swapfile as a safety net for memory spikes during Nix builds.
+    fallocate -l 2G /swapfile
+    chmod 600 /swapfile
+    mkswap /swapfile
+    swapon /swapfile
+    echo '/swapfile none swap sw 0 0' >> /etc/fstab
   EOT
   )
 

--- a/management/jump_box_ssm.tf
+++ b/management/jump_box_ssm.tf
@@ -27,6 +27,9 @@ resource "aws_ssm_document" "session_preferences" {
       cloudWatchStreamingEnabled  = true
       runAsEnabled                = true
       runAsDefaultUser            = "ec2-user"
+      shellProfile = {
+        linux = "exec bash -l"
+      }
     }
   })
 


### PR DESCRIPTION
## Summary

- Adds `shellProfile.linux = "exec bash -l"` to the SSM session document — sessions now start as a login bash shell, so `.bashrc` is sourced and `nix` is on PATH immediately
- Adds a 2 GiB swapfile in `user_data` as a safety net for memory spikes during Nix builds (persisted via `/etc/fstab`)

The SSM document change takes effect immediately on next apply (no instance replacement). The swapfile requires instance replacement via `user_data_replace_on_change`.

Closes #22

## Test plan

- [x] CI passes
- [ ] After apply: new SSM session opens with `bash-5.2$` prompt (not `sh-5.2$`)
- [ ] `nix --version` works without running `bash` first
- [ ] `free -h` shows 2 GiB swap after instance replacement

🤖 Generated with [Claude Code](https://claude.com/claude-code)