### PR TITLE
fix: run jump box as otto user to match home-manager config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ The instance has an IAM instance profile (`shared-jump-box-management`) with:
 - `AdministratorAccess` on the management account
 - `sts:AssumeRole` into `shared-jump-box-role` in each member account
 
-Sessions run as `ec2-user` and are logged to CloudWatch (`/ssm/jump-box-sessions`, 90-day retention).
+Sessions run as `otto` and are logged to CloudWatch (`/ssm/jump-box-sessions`, 90-day retention).
 
 Nix is installed at first launch (Determinate Systems installer, daemon mode, flakes enabled). Apply `ojhermann-org/home-manager` on first login to complete the environment setup.
 

--- a/management/jump_box_ec2.tf
+++ b/management/jump_box_ec2.tf
@@ -27,17 +27,20 @@ resource "aws_instance" "jump_box" {
   # Install Nix via Determinate Systems installer (daemon mode, flakes enabled by default).
   # The installer creates /etc/profile.d/nix.sh which sources nix-daemon.sh at login,
   # so nix is on PATH for all login shells without any .bashrc modifications.
-  # Home Manager is applied as ec2-user so the user environment is fully configured
-  # on first boot — no manual steps needed on new instances.
+  # An `otto` user is created to match the home-manager configuration; Home Manager is
+  # applied as otto so the user environment is fully configured on first boot.
   # A 2 GiB swapfile is created to guard against OOM during Nix builds.
   user_data = base64encode(<<-EOT
     #!/bin/bash
     set -euo pipefail
+    # Create otto user (matches home-manager config) with sudo access.
+    useradd -m -s /bin/bash otto
+    usermod -aG wheel otto
     curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix \
       | sh -s -- install --no-confirm
-    # Apply Home Manager as ec2-user in a login shell so nix is on PATH via
+    # Apply Home Manager as otto in a login shell so nix is on PATH via
     # /etc/profile.d/nix.sh. This fully configures the user environment on first boot.
-    sudo -u ec2-user bash -lc \
+    sudo -u otto bash -lc \
       'nix run home-manager/master -- switch --flake github:ojhermann-org/home-manager#otto@x86_64-linux --refresh'
     # Create a 2 GiB swapfile as a safety net for memory spikes during Nix builds.
     fallocate -l 2G /swapfile

--- a/management/jump_box_ssm.tf
+++ b/management/jump_box_ssm.tf
@@ -11,7 +11,7 @@ resource "aws_cloudwatch_log_group" "ssm_sessions" {
 }
 
 # Overrides SSM Session Manager defaults for all sessions on this account.
-# Sets CloudWatch logging and runs sessions as ec2-user (who has the nix environment).
+# Sets CloudWatch logging and runs sessions as otto (who has the nix environment).
 resource "aws_ssm_document" "session_preferences" {
   name            = "SSM-SessionManagerRunShell"
   document_type   = "Session"
@@ -19,14 +19,14 @@ resource "aws_ssm_document" "session_preferences" {
 
   content = jsonencode({
     schemaVersion = "1.0"
-    description   = "Session Manager preferences: CloudWatch logging, run as ec2-user"
+    description   = "Session Manager preferences: CloudWatch logging, run as otto"
     sessionType   = "Standard_Stream"
     inputs = {
       cloudWatchLogGroupName      = aws_cloudwatch_log_group.ssm_sessions.name
       cloudWatchEncryptionEnabled = false
       cloudWatchStreamingEnabled  = true
       runAsEnabled                = true
-      runAsDefaultUser            = "ec2-user"
+      runAsDefaultUser            = "otto"
       shellProfile = {
         linux = "exec bash -l"
       }


### PR DESCRIPTION
## Summary

- Creates an `otto` user on first boot (wheel group for sudo access)
- Switches Nix + Home Manager bootstrap from `ec2-user` to `otto`
- Updates SSM session default user to `otto`

Home Manager manages `~/.aws/config`, so no manual setup is needed after the instance boots.

Applying this will replace the existing instance (due to `user_data_replace_on_change = true`), which is intentional — it validates the full bootstrap sequence.

## Test plan

- [ ] Apply runs cleanly and replaces the instance
- [ ] SSM session connects and lands as `otto`
- [ ] Nix and home-manager environment is present (e.g. `which git`, `nix --version`)
- [ ] `~/.aws/config` is present and profiles work

🤖 Generated with [Claude Code](https://claude.com/claude-code)