### PR TITLE
fix: use name_prefix and create_before_destroy on jump box SG

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,7 @@ Guidelines:
 - Run `tofu fmt` before committing
 - Update this file whenever conventions, structure, or account details change
 - Keep CI in sync with the repo: when a new account directory is added, add it to the `plan` matrix in `.github/workflows/ci.yml`
+- **Attachment resources** (security groups, IAM instance profiles, launch templates, RDS/ElastiCache parameter and subnet groups) must use `lifecycle { create_before_destroy = true }` — these block their own deletion while a running resource holds a reference, so OpenTofu must create the replacement before destroying the original to avoid AWS "dependency violation" errors. Use `name_prefix` instead of `name` where AWS allows generated names (security groups, launch templates), so the new resource can be created while the old one still exists. Do not apply this pattern to stateful resources (RDS instances, DynamoDB tables), globally-named resources (S3 buckets, IAM roles), or infrastructure primitives (VPCs, subnets, IGWs) — for those, replacement is a significant event that warrants explicit control
 
 ## Bootstrap sequence
 

--- a/management/jump_box_network.tf
+++ b/management/jump_box_network.tf
@@ -60,7 +60,7 @@ resource "aws_route_table_association" "management_public" {
 # Outbound HTTPS is required for the instance to reach SSM endpoints.
 # Outbound SSH is required to connect to external hosts (e.g. GitHub) over SSH.
 resource "aws_security_group" "jump_box" {
-  name        = "shared-sg-jump-box-management"
+  name_prefix = "shared-sg-jump-box-management-"
   description = "Jump box: no inbound; outbound HTTPS for SSM and SSH for git remotes"
   vpc_id      = aws_vpc.management.id
 
@@ -85,5 +85,9 @@ resource "aws_security_group" "jump_box" {
     env        = "management"
     service    = "shared"
     managed-by = "opentofu"
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }


### PR DESCRIPTION
## Summary

- Switches the jump box SG from `name` to `name_prefix` so a replacement SG can be created while the old one still exists in the same VPC
- Adds `lifecycle { create_before_destroy = true }` so the new SG is created and attached to the instance before the old one is deleted — avoiding the `DependencyViolation` error we hit in #27
- Updates `CLAUDE.md` with a convention covering all attachment resources (security groups, IAM instance profiles, launch templates, RDS/ElastiCache parameter and subnet groups)

## Context

Run #27 failed after ~15 minutes with `DependencyViolation: resource sg-0f459e2f373a67738 has a dependent object`. The SG replacement was triggered by the description change in that PR; OpenTofu's default destroy-then-create order tried to delete the old SG while the instance was still attached to it. The AWS state is clean (no partial changes were applied), so this PR will complete that replacement safely.

## Test plan

- [ ] `tofu apply` completes without error
- [ ] Instance is attached to a new SG with the `shared-sg-jump-box-management-` prefix
- [ ] Old SG `sg-0f459e2f373a67738` is deleted
- [ ] `ssh -T git@github.com` from the jump box succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)