### PR TITLE
feat: add ci gate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,14 @@ jobs:
       - name: plan
         run: tofu plan -input=false -lock=false
         working-directory: ${{ matrix.directory }}
+
+  ci:
+    needs: [plan]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check all jobs passed
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" || "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -3,3 +3,14 @@
 Managing Otto's AWS infrastructure using [OpenTofu](https://opentofu.org), following [AWS Organizations best practices](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_best-practices.html).
 
 See [CLAUDE.md](CLAUDE.md) for conventions, account structure, and bootstrap status.
+
+## CI
+
+The `ci` job is required to pass before merging to `main`, enforced by the org-level ruleset in [github-settings](https://github.com/ojhermann-org/github-settings). `fmt` and `trivy` run in parallel, then `plan` runs across all four account directories as a matrix, then `ci` gates on all of them.
+
+```mermaid
+graph LR
+  fmt --> plan
+  trivy --> plan
+  plan["plan × 4 (management, dev, stage, prod)"] --> ci
+```


### PR DESCRIPTION
## Summary

- Adds a `ci` gate job to `.github/workflows/ci.yml` that gates on `plan` (which already depends on `fmt` and `trivy`)
- Adds a CI section to `README.md` with a Mermaid dependency graph

## Context

The org-level ruleset in [github-settings](https://github.com/ojhermann-org/github-settings) (see ojhermann-org/github-settings#34) requires a check named `ci` to pass before merging to the default branch across all repos. This PR adds the `ci` job that satisfies that requirement.

The `ci` job does no work itself — it gates on `plan` (all four matrix instances: management, dev, stage, prod), and uses `if: always()` so it fails rather than skips when an upstream job fails. `needs: [plan]` is sufficient since `plan` already depends on `fmt` and `trivy`.

```mermaid
graph LR
  fmt --> plan
  trivy --> plan
  plan["plan × 4 (management, dev, stage, prod)"] --> ci
```

## Test plan

- [ ] Confirm CI passes on this PR (all jobs including `ci`)
- [ ] Merge ojhermann-org/github-settings#34 and run `tofu apply`
- [ ] Verify a subsequent PR is blocked without `ci` passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)