### PR TITLE
fix: replace nested heredocs with printf in user_data

### DIFF
--- a/management/jump_box_ec2.tf
+++ b/management/jump_box_ec2.tf
@@ -57,20 +57,16 @@ resource "aws_instance" "jump_box" {
     # PAM limits cover login shells and su sessions; the systemd drop-ins cover
     # services launched by systemd (including user@.service sessions), which PAM
     # limits do not reach.
+    # Note: nested heredocs (<<'EOF') would introduce 0-indented lines that break
+    # HCL's <<-EOT stripping and push the shebang off byte 0; use printf instead.
     mkdir -p /etc/security/limits.d
-    cat > /etc/security/limits.d/90-otto-stack.conf <<'EOF'
-otto hard stack 61440
-otto soft stack 61440
-EOF
+    printf 'otto hard stack 61440\notto soft stack 61440\n' \
+      > /etc/security/limits.d/90-otto-stack.conf
     mkdir -p /etc/systemd/system.conf.d /etc/systemd/user.conf.d
-    cat > /etc/systemd/system.conf.d/stack.conf <<'EOF'
-[Manager]
-DefaultLimitSTACK=62914560
-EOF
-    cat > /etc/systemd/user.conf.d/stack.conf <<'EOF'
-[Manager]
-DefaultLimitSTACK=62914560
-EOF
+    printf '[Manager]\nDefaultLimitSTACK=62914560\n' \
+      > /etc/systemd/system.conf.d/stack.conf
+    printf '[Manager]\nDefaultLimitSTACK=62914560\n' \
+      > /etc/systemd/user.conf.d/stack.conf
     systemctl daemon-reexec
     # Create a 2 GiB swapfile as a safety net for memory spikes during Nix builds.
     fallocate -l 2G /swapfile


### PR DESCRIPTION
## Root cause

The nested `<<'EOF'` blocks I added in #36 (for the PAM limits and systemd drop-in files) introduced lines with **0 indentation** inside the HCL `<<-EOT` heredoc. HCL's indented heredoc strips leading spaces equal to the **minimum indentation across all content lines** — so adding 0-indented lines dropped the strip amount to 0. This left 4 spaces before the `#!/bin/bash` shebang, causing a kernel exec format error. The `user_data` script never ran, so the `otto` user was never created and SSH access was never provisioned.

## Fix

Replace the nested heredocs with `printf` calls. Every line in the HCL heredoc stays at ≥4 spaces of indentation, so `<<-EOT` correctly strips them and the shebang lands at byte 0.

## Test plan

- [x] Merge and `tofu apply` in `management/` — jump box will be replaced (1 add / 1 destroy)
- [x] `jump` connects successfully after the new instance finishes bootstrapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)